### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/.nuke
+++ b/.nuke
@@ -1,1 +1,0 @@
-VirtoCommerce.ShipStationModule.sln

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./build.schema.json",
+  "Solution": "VirtoCommerce.ShipStationModule.sln"
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,12 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.803.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-rvv3-g6hj-g44x" />
+  </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ShipStationModule.Core/VirtoCommerce.ShipStationModule.Core.csproj
+++ b/src/VirtoCommerce.ShipStationModule.Core/VirtoCommerce.ShipStationModule.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.800.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    
   </ItemGroup>
 </Project>
 

--- a/src/VirtoCommerce.ShipStationModule.Data/VirtoCommerce.ShipStationModule.Data.csproj
+++ b/src/VirtoCommerce.ShipStationModule.Data/VirtoCommerce.ShipStationModule.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -27,12 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
+    
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
   </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.ShipStationModule.Web/VirtoCommerce.ShipStationModule.Web.csproj
+++ b/src/VirtoCommerce.ShipStationModule.Web/VirtoCommerce.ShipStationModule.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/src/VirtoCommerce.ShipStationModule.Web/module.manifest
+++ b/src/VirtoCommerce.ShipStationModule.Web/module.manifest
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <id>VirtoCommerce.ShipStation</id>
-    <version>3.803.0</version>
+    <version>3.1000.0</version>
     <version-tag />
-    <platformVersion>3.800.0</platformVersion>
+    <platformVersion>3.1002.0</platformVersion>
     <title>ShipStation Integration</title>
     <description>Enables synchronizing customer orders with ShipStation</description>
     <authors>
@@ -16,12 +16,12 @@
     <iconUrl>Modules/$(VirtoCommerce.ShipStation)/Content/logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes>First version.</releaseNotes>
-    <copyright>Copyright © 2024 VirtoCommerce. All rights reserved</copyright>
+    <copyright>Copyright © 2024-2026 VirtoCommerce. All rights reserved</copyright>
     <tags>extension module</tags>
     <assemblyFile>VirtoCommerce.ShipStationModule.Web.dll</assemblyFile>
     <moduleType>VirtoCommerce.ShipStationModule.Web.Module, VirtoCommerce.ShipStationModule.Web</moduleType>
     <dependencies>
-        <dependency id="VirtoCommerce.Orders" version="3.800.0" />
+        <dependency id="VirtoCommerce.Orders" version="3.1000.0" />
     </dependencies>
     <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
 </module>

--- a/tests/VirtoCommerce.ShipStationModule.Tests/VirtoCommerce.ShipStationModule.Tests.csproj
+++ b/tests/VirtoCommerce.ShipStationModule.Tests/VirtoCommerce.ShipStationModule.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
feat: Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ShipStation_3.1000.0-pr-13-484a.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades target framework and several core/test dependencies, which can introduce build/runtime incompatibilities and require downstream platform alignment, but does not change business logic.
> 
> **Overview**
> Upgrades the ShipStation module (core, data, web, and tests) to target `net10.0` and bumps module/platform versioning to the `3.1000.x` line, including updated VirtoCommerce package references and manifest dependency/platform requirements.
> 
> Build/test tooling is refreshed by updating EF Core tools and moving tests to `xunit.v3` with newer `Microsoft.NET.Test.Sdk`/`coverlet`, adds a NUKE `parameters.json` for solution configuration, and suppresses a specific NuGet audit advisory via `Directory.Build.props`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 484a315a93b6b20ab2145f7f42740ab7da38c922. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->